### PR TITLE
Fix installation.

### DIFF
--- a/sets/kde4/Makefile
+++ b/sets/kde4/Makefile
@@ -94,8 +94,6 @@ spelling \
 
 # links to Messages.sh plugins
 MSG_PLUGINS = \
-endswithnewline \
-filenames \
 rcappend \
 
 # links to QML plugins

--- a/sets/kde5/Makefile
+++ b/sets/kde5/Makefile
@@ -91,8 +91,6 @@ spelling \
 
 # links to Messages.sh plugins
 MSG_PLUGINS = \
-endswithnewline \
-filenames \
 rcappend \
 
 # links to QML plugins


### PR DESCRIPTION
the endwithnewline and filenames plugins are not in the PLUGINLNS list
in plugins/messages/Makefile.

This causes an error when installing krazy.